### PR TITLE
Set physic indipendent from FPS

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_resource(RapierConfiguration {
             gravity: Vector2::zeros(),
+            time_dependent_number_of_timesteps: true, //physic run at fixed 60Hz
             ..Default::default()
         })
         .add_resource(State::new(AppState::StartMenu))


### PR DESCRIPTION
by adding `time_dependent_number_of_timesteps: true` we make the physic step run at constant 16ms instead of every frame; this make the game playable on PC that can do many FPS

edit: compiling in --release I jumped from ~160 FPS to ~2000 FPS and is clear the flag, while it does make the situation better, is still not enough; without flag at ~2000fps touching any input immediately break the physics (ship basically teleporting around the screen), with the flag it is similar to the experience at 160fps without flag, everything speed up but still barely playable

edit2: the problem seems to be the user input, or the system is somehow attached to the physic instead of the GUI, or the input is scaled by the fps time